### PR TITLE
fix: avatar redirects to GitHub profile

### DIFF
--- a/src/components/PostGrid.jsx
+++ b/src/components/PostGrid.jsx
@@ -14,6 +14,10 @@ function PostGrid({ data }) {
     option === "issues" ? window.open(`${repoLink}/issues`) : window.open(repoLink);
   };
 
+  const handleRedirect = (contributor) => {
+    window.open(`https://github.com/${contributor}`);
+  };
+
   return (
     <div className=" bg-offWhite rounded-xl p-6 font-roboto cursor-pointer ">
       {/* Avator Container */}
@@ -25,6 +29,7 @@ function PostGrid({ data }) {
             alt="Avatar 01"
             width={500}
             height={500}
+            onClick={() => handleRedirect(data?.contributors[0])}
           />
         </div>
         <div className="bg-blue-400 w-10 h-10 overflow-hidden  rounded-full mr-3 ">
@@ -34,6 +39,7 @@ function PostGrid({ data }) {
             alt="Avatar 02"
             width={500}
             height={500}
+            onClick={() => handleRedirect(data?.contributors[1])}
           />
         </div>
       </div>
@@ -58,14 +64,20 @@ function PostGrid({ data }) {
         </div>
 
         {/* Issues */}
-        <div className=" flex justify-center items-center text-xl text-grey hover:text-saucyRed cursor-pointer transition-all duration-200  "  onClick={() => handleClick("issues")}>
+        <div
+          className=" flex justify-center items-center text-xl text-grey hover:text-saucyRed cursor-pointer transition-all duration-200  "
+          onClick={() => handleClick("issues")}
+        >
           <i className="fas fa-comment-dots mr-2 "></i>
 
           {data.issues && <p className="font-bold">{humanizeNumber(data.issues)}</p>}
         </div>
 
         {/* Stars */}
-        <div className=" flex justify-center items-center text-xltext-grey hover:text-saucyRed cursor-pointer transition-all duration-200 " onClick={handleClick}>
+        <div
+          className=" flex justify-center items-center text-xltext-grey hover:text-saucyRed cursor-pointer transition-all duration-200 "
+          onClick={handleClick}
+        >
           <i className="fas fa-star mr-2 "></i>
           {data.total_stars && <p className="font-bold">{humanizeNumber(data.stars)}</p>}
         </div>

--- a/src/components/PostList.jsx
+++ b/src/components/PostList.jsx
@@ -11,6 +11,9 @@ function PostList({ data }) {
   const handleClick = (option) => {
     option === "issues" ? window.open(`${repoLink}/issues`) : window.open(repoLink);
   };
+  const handleRedirect = (contributor) => {
+    window.open(`https://github.com/${contributor}`);
+  };
 
   return (
     <div className=" bg-offWhite rounded-xl p-6 font-roboto w-full cursor-pointer">
@@ -26,6 +29,7 @@ function PostList({ data }) {
               alt="Avatar 01"
               width={500}
               height={500}
+              onClick={() => handleRedirect(data?.contributors[0])}
             />
           </div>
           {/* Avatar */}
@@ -36,6 +40,7 @@ function PostList({ data }) {
               alt="Avatar 02"
               width={500}
               height={500}
+              onClick={() => handleRedirect(data?.contributors[1])}
             />
           </div>
         </div>
@@ -58,14 +63,20 @@ function PostList({ data }) {
             </div>
 
             {/* Issues */}
-            <div className=" flex justify-center items-center text-xl  text-grey hover:text-saucyRed cursor-pointer transition-all duration-200  " onClick={() => handleClick("issues")}>
+            <div
+              className=" flex justify-center items-center text-xl  text-grey hover:text-saucyRed cursor-pointer transition-all duration-200  "
+              onClick={() => handleClick("issues")}
+            >
               <i className="fas fa-comment-dots mr-2 "></i>
 
               {data.issues && <p className="font-bold">{humanizeNumber(data.issues)}</p>}
             </div>
 
             {/* Stars */}
-            <div className=" flex justify-center items-center text-xl  text-grey hover:text-saucyRed cursor-pointer transition-all duration-200 " onClick={handleClick}>
+            <div
+              className=" flex justify-center items-center text-xl  text-grey hover:text-saucyRed cursor-pointer transition-all duration-200 "
+              onClick={handleClick}
+            >
               <i className="fas fa-star mr-2 "></i>
               {data.total_stars && <p className="font-bold">{humanizeNumber(data.stars)}</p>}
             </div>


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/open-sauced/blob/HEAD/CONTRIBUTING.md#create-a-pull-request.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/open-sauced/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] 🐛 Bug Fix

## Description

<!-- Please do not leave this blank -->

This PR adds the feature of redirecting you from the contributor's avatar that you clicked to their respective GitHub profile. This feature was added to the PostGrid and PostList JSX files

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
Fixes #29 

## Added tests?

- [x] 🙅 no, because they aren't needed

## Added to documentation?

- [x] 🙅 no documentation needed



<!-- note: PRs with deletes sections will be marked invalid -->

