### PR TITLE
fix: PostList overlapping view correction

### DIFF
--- a/src/components/PostList.jsx
+++ b/src/components/PostList.jsx
@@ -20,9 +20,9 @@ function PostList({ data }) {
       {/* Flex container */}
       <div className="flex ">
         {/* Avatar Container */}
-        <div className=" flex flex-col ">
+        <div className=" flex flex-col justify-center items-center">
           {/* Avatar */}
-          <div className="bg-blue-400 w-10 h-10 overflow-hidden  rounded-full mb-2 ">
+          <div className="bg-blue-400 w-7 sm:w-10 h-7 sm:h-10 overflow-hidden  rounded-full mb-2 ">
             <img
               className="object-cover"
               src={getAvatar(data?.contributors[0])}
@@ -33,7 +33,7 @@ function PostList({ data }) {
             />
           </div>
           {/* Avatar */}
-          <div className="bg-blue-400 w-10 h-10 overflow-hidden  rounded-full ">
+          <div className="bg-blue-400 w-7 sm:w-10 h-7 sm:h-10 overflow-hidden  rounded-full ">
             <img
               className="object-cover"
               src={getAvatar(data?.contributors[1])}
@@ -46,25 +46,28 @@ function PostList({ data }) {
         </div>
 
         {/* Content */}
-        <div className=" ml-5 border-l-2 pl-5">
-          <div className=" text-grey text-md font-medium  overflow-hidden cursor-pointer " onClick={handleClick}>
+        <div className=" ml-5 border-l-2 pl-3 space-y-2">
+          <div
+            className=" text-grey text-xs sm:text-lg font-medium  overflow-hidden cursor-pointer"
+            onClick={handleClick}
+          >
             <h1>{data.repo_name} </h1>
           </div>
           {/* Description */}
-          <div className=" text-lightGrey text-sm mb-2 ">
+          <div className=" text-lightGrey text-xs sm:text-base">
             <h3> {data.description} </h3>
           </div>
           {/* Action Button Container */}
           <div className=" flex justify-between w-full ">
             {/* Upvote */}
-            <div className=" flex justify-center items-center text-xl text-grey hover:text-saucyRed cursor-pointer transition-all duration-200  ">
+            <div className=" flex justify-center items-center text-xs sm:text-xl text-grey hover:text-saucyRed cursor-pointer transition-all duration-200  ">
               <i className="fas fa-arrow-alt-circle-up mr-2 "></i>
               <p className="font-bold">5</p>
             </div>
 
             {/* Issues */}
             <div
-              className=" flex justify-center items-center text-xl  text-grey hover:text-saucyRed cursor-pointer transition-all duration-200  "
+              className=" flex justify-center items-center text-xs sm:text-xl  text-grey hover:text-saucyRed cursor-pointer transition-all duration-200  "
               onClick={() => handleClick("issues")}
             >
               <i className="fas fa-comment-dots mr-2 "></i>
@@ -74,7 +77,7 @@ function PostList({ data }) {
 
             {/* Stars */}
             <div
-              className=" flex justify-center items-center text-xl  text-grey hover:text-saucyRed cursor-pointer transition-all duration-200 "
+              className=" flex justify-center items-center text-xs sm:text-xl  text-grey hover:text-saucyRed cursor-pointer transition-all duration-200 "
               onClick={handleClick}
             >
               <i className="fas fa-star mr-2 "></i>

--- a/src/components/PostsWrap.jsx
+++ b/src/components/PostsWrap.jsx
@@ -19,7 +19,7 @@ const PostsWrap = () => {
             ))}
           </div>
         ) : (
-          <div className=" container grid gap-3 ">
+          <div className=" container space-y-3 ">
             {postData.map((item, i) => (
               <PostList data={item} key={i} />
             ))}


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/open-sauced/blob/HEAD/CONTRIBUTING.md#create-a-pull-request.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/open-sauced/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] 🐛 Bug Fix

## Description

<!-- Please do not leave this blank -->

This PR fixes the bug that shows up on mobile view when you switch from grid view to list view. The cards start to overflow out of the screen and it makes it look weird. I have made the necessary correction and everything looks fine now

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
Fixes #53 

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->
Screenshot of what my change looks like

![Screenshot 2022-01-01 134737](https://user-images.githubusercontent.com/16826624/147850907-b17af1cb-d033-4b48-8077-d93c9c116d65.png)

## Added tests?

- [x] 🙅 no, because they aren't needed

## Added to documentation?

- [x] 🙅 no documentation needed

<!-- note: PRs with deletes sections will be marked invalid -->

