### PR TITLE
fix: badge not loading in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="https://github.com/open-sauced/hot/actions/workflows/codeql-analysis.yml">
     <img src="https://github.com/open-sauced/hot/actions/workflows/codeql-analysis.yml/badge.svg" alt="CodeQL" style="max-width: 100%;">
   </a>
-  <img src="https://badgen.net/dependabot/open-sauced/hot?icon=dependabot" alt="Dependabot Badge">
+  <img src="https://badgen.net/badge/icon/dependabot?icon=dependabot&label" alt="Dependabot Badge">
   <img src="https://img.shields.io/github/languages/code-size/open-sauced/hot" alt="GitHub code size in bytes">
   <img src="https://img.shields.io/github/commit-activity/w/open-sauced/hot" alt="GitHub commit activity">
   <a href="https://github.com/open-sauced/hot/issues">


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/open-sauced/blob/HEAD/CONTRIBUTING.md#create-a-pull-request.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/open-sauced/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

This PR fixes the dependabot badge not loading in the README file. 

## Related Tickets & Documents

Fixes #98 

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [x] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed
