### PR TITLE
fix: add a min-height to the load more button to match the card height

### DIFF
--- a/src/components/GridDisplay.tsx
+++ b/src/components/GridDisplay.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
-import PostGrid from './PostGrid';
-import {User} from "@supabase/supabase-js";
+import React from "react";
+import PostGrid from "./PostGrid";
+import { User } from "@supabase/supabase-js";
 
 export declare interface GridDisplayProps {
   activeLink: string | null;
@@ -10,19 +10,20 @@ export declare interface GridDisplayProps {
   user: User | null;
 }
 
-const GridDisplay = ({activeLink, limit, handleLoadingMore, fetchedData, user}: GridDisplayProps): JSX.Element => (
+const GridDisplay = ({ activeLink, limit, handleLoadingMore, fetchedData, user }: GridDisplayProps): JSX.Element => (
   <div>
     <div className="container grid xs:grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 max-w-screen-xl mx-auto">
       {fetchedData.map((item, i) => (
-        <PostGrid user={user} data={item} key={`${item.repo_name}_${i}`}/>))}
-      {fetchedData.length > 0
-        && activeLink !== 'myVotes'
-        && limit <= 100
-        && <button onClick={() => handleLoadingMore()}
-          className="bg-grey hover:bg-lightGrey text-white font-bold py-2 px-4 rounded-xl">
+        <PostGrid user={user} data={item} key={`${item.repo_name}_${i}`} />
+      ))}
+      {fetchedData.length > 0 && activeLink !== "myVotes" && limit <= 100 && (
+        <button
+          onClick={() => handleLoadingMore()}
+          className="bg-grey hover:bg-lightGrey text-white font-bold py-2 px-4 rounded-xl min-h-[220px]"
+        >
           Load More
         </button>
-      }
+      )}
     </div>
   </div>
 );

--- a/src/components/GridDisplay.tsx
+++ b/src/components/GridDisplay.tsx
@@ -12,14 +12,14 @@ export declare interface GridDisplayProps {
 
 const GridDisplay = ({ activeLink, limit, handleLoadingMore, fetchedData, user }: GridDisplayProps): JSX.Element => (
   <div>
-    <div className="container grid xs:grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 max-w-screen-xl mx-auto">
+    <div className="container grid xs:grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 max-w-screen-xl mx-auto auto-rows-fr">
       {fetchedData.map((item, i) => (
         <PostGrid user={user} data={item} key={`${item.repo_name}_${i}`} />
       ))}
       {fetchedData.length > 0 && activeLink !== "myVotes" && limit <= 100 && (
         <button
           onClick={() => handleLoadingMore()}
-          className="bg-grey hover:bg-lightGrey text-white font-bold py-2 px-4 rounded-xl min-h-[220px]"
+          className="bg-grey hover:bg-lightGrey text-white font-bold py-2 px-4 rounded-xl"
         >
           Load More
         </button>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR fixes #128 by adding a min-height to the load more button when it is the only item on a new row

## Related Tickets & Documents
fixes #128

## Mobile & Desktop Screenshots/Recordings


![Screen Shot 2022-03-08 at 5 40 49 PM](https://user-images.githubusercontent.com/16832258/157338012-31147c5f-234b-48ab-b4f1-2ff098deadee.png)

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

Just a double check to make sure everything is good in production

## [optional] What gif best describes this PR or how it makes you feel?
![chef's kiss](https://c.tenor.com/Gri2PCFt0NoAAAAC/kirakirakrystal-chefs-kiss.gif)


<!-- note: PRs with deletes sections will be marked invalid -->

