### PR TITLE
feat: updated CSS to respect row in subnav

### DIFF
--- a/src/components/SecondaryNav.tsx
+++ b/src/components/SecondaryNav.tsx
@@ -36,7 +36,7 @@ const SecondaryNav = ({ activeLink, user }: SecondaryNavProps): JSX.Element => {
     <div>
       <div className="bg-darkestGrey py-14 md:py-16">
         <nav className="container">
-          <div className="flex space-y-2 flex-row text-xl font-righteous text-accent font-bold justify-center items-baseline cursor-pointer">
+          <div className="flex space-y-2 flex-row text-sm sm:text-xl font-righteous text-accent font-bold justify-center items-baseline cursor-pointer">
             {links.map(({ link, title }) => (
               <Link
                 key={link}

--- a/src/components/SecondaryNav.tsx
+++ b/src/components/SecondaryNav.tsx
@@ -36,7 +36,7 @@ const SecondaryNav = ({ activeLink, user }: SecondaryNavProps): JSX.Element => {
     <div>
       <div className="bg-darkestGrey py-14 md:py-16">
         <nav className="container">
-          <div className="flex flex-col space-y-2 sm:flex-row text-xl font-righteous text-accent font-bold justify-center items-baseline cursor-pointer">
+          <div className="flex space-y-2 flex-row text-xl font-righteous text-accent font-bold justify-center items-baseline cursor-pointer">
             {links.map(({ link, title }) => (
               <Link
                 key={link}


### PR DESCRIPTION

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/open-sauced/blob/HEAD/CONTRIBUTING.md#create-a-pull-request.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/open-sauced/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
Deleted flex-col and sm:flex-row in CSS for the subnav in mobile view as opposed to adding code.
Replaced with only flex-row for the subnav to display horizontally in mobile view.
<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
fix #221

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->
![2F413F4C-70B4-416B-98C8-88FEFF478497_4_5005_c](https://user-images.githubusercontent.com/9039234/183741421-e128dd20-d955-4eb7-8e19-6383836a8b98.jpeg)


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->
![smug-daniel-craig](https://user-images.githubusercontent.com/9039234/183743918-61e8df86-dc25-41b5-b0da-b6d9a85d4b7e.gif)

