### PR TITLE
fix: correct tailwind antipattern

### DIFF
--- a/src/components/StackedAvatar.tsx
+++ b/src/components/StackedAvatar.tsx
@@ -8,7 +8,7 @@ const StackedAvatar = ({ contributors }: StackedAvatarProps) => (
     {contributors && contributors.slice(0, 5).map(({ contributor, last_merged_at }) => (
       <div
         key={`contributor-avatar-${contributor}`}
-        className="w-[24px] h-[24px] overflow-hidden rounded-full transition-all duration-300"
+        className="w-6 h-6 overflow-hidden rounded-full transition-all duration-300"
       >
         <Avatar
           contributor={contributor}


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/open-sauced/blob/HEAD/CONTRIBUTING.md#create-a-pull-request.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/open-sauced/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
Corrects tailwind classes not to use one-off width/height styles.
Following https://tailwindcss.com/docs/width for reference.

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
Fixes #318 

## Mobile & Desktop Screenshots/Recordings
Before:
![Screen Shot 2022-08-27 at 9 32 31 PM](https://user-images.githubusercontent.com/3792749/187054169-0f867b0d-4dba-4903-a6c6-7320358a53a4.png)

After:
<!-- Visual changes require screenshots -->
![Screen Shot 2022-08-27 at 9 37 34 PM](https://user-images.githubusercontent.com/3792749/187054167-e0bd2f7b-fd11-4c60-91d6-15ef12a887c8.png)


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?
![maths](https://media.giphy.com/media/3o7btPCcdNniyf0ArS/giphy-downsized.gif)

<!-- note: PRs with deleted sections will be marked invalid -->

