### PR TITLE
fix: use aria-label instead of title for footer icons

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -25,32 +25,32 @@ const footerContext = [
     socials: [
       {
         icon: AiOutlineTwitter,
-        title: "Twitter",
+        label: "Twitter",
         url: "https://twitter.com/saucedopen",
       },
       {
         icon: AiOutlineGithub,
-        title: "GitHub",
+        label: "GitHub",
         url: "https://github.com/open-sauced",
       },
       {
         icon: AiFillInstagram,
-        title: "Instagram",
+        label: "Instagram",
         url: "https://www.instagram.com/opensauced/",
       },
       {
         icon: AiFillYoutube,
-        title: "YouTube",
+        label: "YouTube",
         url: "https://www.youtube.com/opensauced",
       },
       {
         icon: FaDiscord,
-        title: "Discord",
+        label: "Discord",
         url: "https://discord.com/invite/U2peSNf23P",
       },
       {
         icon: FaDev,
-        title: "Devto",
+        label: "Devto",
         url: "https://dev.to/opensauced/",
       },
     ],
@@ -129,7 +129,7 @@ const Footer = (): JSX.Element => (
             </a>
           </div>
 
-          {footerContext[2].socials?.map(({ icon: Icon, url, title }, index) => (
+          {footerContext[2].socials?.map(({ icon: Icon, label, url }, index) => (
             <a
               key={index}
               href={url}
@@ -137,8 +137,8 @@ const Footer = (): JSX.Element => (
               target="_blank"
             >
               <Icon
+                aria-label={label}
                 className="text-2xl hover:text-light-slate-10 text-light-slate-9"
-                title={title}
               />
             </a>
           ))}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

Uses `aria-label` instead of `title` on footer SVGs per https://html.spec.whatwg.org/multipage/dom.html#the-title-attribute.

## Related Tickets & Documents

* #426 -> #427
* https://twitter.com/hi__mayank/status/1602732880400158720

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?

![Today I Learned in sparkling text, a star animating through](https://user-images.githubusercontent.com/3335181/207423232-1478d6b1-bb36-4942-8c46-59b30964aab0.gif)


<!-- note: PRs with deleted sections will be marked invalid -->

