### PR TITLE
feat: check whether repo is starred for nav UI

### DIFF
--- a/src/components/PrimaryNav.tsx
+++ b/src/components/PrimaryNav.tsx
@@ -1,6 +1,5 @@
 import { Menu, Transition } from "@headlessui/react";
 import { GiHamburgerMenu } from "react-icons/gi";
-import { AiOutlineStar } from "react-icons/ai";
 import { capturePostHogAnayltics } from "../lib/analytics";
 import { getAvatarLink } from "../lib/github";
 import useSupabaseAuth from "../hooks/useSupabaseAuth";
@@ -13,26 +12,13 @@ import RepoSubmission from "./RepoSubmission";
 import { useState, useEffect } from "react";
 import AdminStatsBar from "./AdminStatusBar";
 import { useKey } from "rooks";
+import { StarTheRepo } from "./StarTheRepo";
 
 const bugReportLink =
   "https://github.com/open-sauced/hot/issues/new?assignees=&labels=%F0%9F%91%80+needs+triage%2C%F0%9F%90%9B+bug&template=bug_report.yml&title=Bug%3A+";
 
-const StarTheRepo = (): JSX.Element => (
-  <div className="hidden sm:flex items-center text-osGrey font-Inter">
-    <a
-      href="https://github.com/open-sauced/hot"
-      rel="noreferrer"
-      target="_blank"
-    >
-      <AiOutlineStar className="inline-block mr-2.5" />
-
-      <span className="text-md font-light mr-2.5">Star us on GitHub</span>
-    </a>
-  </div>
-);
-
 const PrimaryNav = (): JSX.Element => {
-  const { signIn, signOut, user } = useSupabaseAuth();
+  const { signIn, signOut, userAndTokens } = useSupabaseAuth();
   const currentUser = supabase.auth.session();
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [openAdminBar, setOpenAdminBar] = useState(false);
@@ -50,11 +36,11 @@ const PrimaryNav = (): JSX.Element => {
     };
 
     fetchAuthSession().catch(err => console.log(err));
-  }, [user]);
+  }, [userAndTokens]);
 
   return (
     <header>
-      { user && openAdminBar && <AdminStatsBar /> }
+      { userAndTokens && openAdminBar && <AdminStatsBar /> }
 
       <div className="flex font-OpenSans py-6 px-10 justify-between max-w-screen-2xl mx-auto">
         <div className="flex items-center text-osGrey">
@@ -69,22 +55,22 @@ const PrimaryNav = (): JSX.Element => {
           </a>
         </div>
 
-        {user && (
+        {userAndTokens && (
           <Menu
             as="div"
             className="flex z-50 text-left relative"
           >
 
             <div className="flex items-center">
-              <StarTheRepo />
+              <StarTheRepo userAndTokens={userAndTokens} />
 
               <Menu.Button>
                 <div className="hidden md:flex pl-4 border-l border-lightOrange">
                   <div className="w-8 h-8 overflow-hidden rounded-full border-osOrange border">
                     <img
-                      alt={String(user.user_metadata.user_name)}
+                      alt={String(userAndTokens.user.user_metadata.user_name)}
                       className="w-full h-full"
-                      src={getAvatarLink(String(user.user_metadata.user_name))}
+                      src={getAvatarLink(String(userAndTokens.user.user_metadata.user_name))}
                     />
                   </div>
                 </div>
@@ -109,19 +95,19 @@ const PrimaryNav = (): JSX.Element => {
                   <div className="flex items-center px-2 py-2.5 mb-1 gap-x-2.5">
                     <div className="flex-col shrink-0 grow-0 w-8 h-8 overflow-hidden rounded-full border-osOrange border">
                       <img
-                        alt={String(user.user_metadata.user_name)}
+                        alt={String(userAndTokens.user.user_metadata.user_name)}
                         className="w-full h-full"
-                        src={getAvatarLink(String(user.user_metadata.user_name))}
+                        src={getAvatarLink(String(userAndTokens.user.user_metadata.user_name))}
                       />
                     </div>
 
                     <div className="flex-col shrink">
                       <p className="text-osGrey text-xs font-semibold">
-                        {user.user_metadata.full_name}
+                        {userAndTokens.user.user_metadata.full_name}
                       </p>
 
                       <p className="text-gray-500 text-xs font-normal">
-                        {user.user_metadata.user_name}
+                        {userAndTokens.user.user_metadata.user_name}
                       </p>
                     </div>
                   </div>
@@ -197,7 +183,7 @@ const PrimaryNav = (): JSX.Element => {
           </Menu>
         )}
 
-        {!user && (
+        {!userAndTokens && (
           <div className="flex items-center">
             <StarTheRepo />
 

--- a/src/components/RepoSubmission.tsx
+++ b/src/components/RepoSubmission.tsx
@@ -10,13 +10,13 @@ export declare interface RepoSubmissionProps {
 }
 
 const RepoSubmission = ({ isFormOpen, handleFormOpen }: RepoSubmissionProps): JSX.Element => {
-  const { user, token } = useSupabaseAuth();
+  const { userAndTokens } = useSupabaseAuth();
   const [isSubmissionInProcess, setIsSubmissionInProcess] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const [input, setInput] = useState("");
   const [submissionRef] = useOutsideClickRef(handleClickOutsideRepoSubmission);
 
-  const userName = String(user?.user_metadata.user_name);
+  const userName = String(userAndTokens?.user.user_metadata.user_name);
 
   const saveToDataBase = (repoUrl: string): void => {
     setIsSubmissionInProcess(true);
@@ -38,8 +38,8 @@ const RepoSubmission = ({ isFormOpen, handleFormOpen }: RepoSubmissionProps): JS
 
       setSubmitted(true);
 
-      if (token) {
-        const resp = await submitRepo(sanitizedUrl, token);
+      if (userAndTokens) {
+        const resp = await submitRepo(sanitizedUrl, userAndTokens.supabaseToken);
 
         try {
           if (resp.status === 200) {

--- a/src/components/SecondaryNav.tsx
+++ b/src/components/SecondaryNav.tsx
@@ -4,7 +4,7 @@ import locationsHash from "../lib/locationsHash";
 import { RepoOrderByEnum } from "./RepoListWrap";
 
 const SecondaryNav = (): JSX.Element => {
-  const { user } = useSupabaseAuth();
+  const { userAndTokens } = useSupabaseAuth();
   const location = useLocation();
   const activeLink = (locationsHash[location.pathname] ?? "recent") as keyof typeof RepoOrderByEnum;
 
@@ -27,7 +27,7 @@ const SecondaryNav = (): JSX.Element => {
     },
   ];
 
-  user &&
+  userAndTokens &&
     links.push({
       link: "myVotes",
       title: "My Votes",

--- a/src/components/StarTheRepo.tsx
+++ b/src/components/StarTheRepo.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import { AiFillStar, AiOutlineStar } from "react-icons/ai";
+import { UserAndTokens } from "../hooks/useSupabaseAuth";
+import { getUserStarredHotRepo } from "../lib/githubAPI";
+
+export interface StarTheRepoProps {
+  userAndTokens?: UserAndTokens;
+}
+
+enum RepoStarred {
+  Anonymous,
+  Pending,
+  NotStarred,
+  Starred,
+}
+
+export const StarTheRepo = ({ userAndTokens }: StarTheRepoProps): JSX.Element | null => {
+  const [starred, setStarred] = useState(RepoStarred.Pending);
+  const opacity = starred === RepoStarred.Pending ? 0 : 100;
+  const [Icon, message] = starred === RepoStarred.Starred ? [AiFillStar, "Starred on GitHub"] : [AiOutlineStar, "Star us on GitHub"];
+
+  useEffect(() => {
+    if (!userAndTokens?.providerToken) {
+      setStarred(RepoStarred.Anonymous);
+      return;
+    }
+
+    setStarred(RepoStarred.Pending);
+
+    getUserStarredHotRepo(userAndTokens.providerToken)
+      .then(isStarred => setStarred(isStarred ? RepoStarred.Starred : RepoStarred.NotStarred))
+      .catch(() => setStarred(RepoStarred.NotStarred));
+  }, [userAndTokens?.providerToken]);
+
+  return (
+    <div className={`hidden sm:flex items-center opacity-${opacity} text-osGrey transition-opacity font-Inter`}>
+      <a
+        href="https://github.com/open-sauced/hot"
+        rel="noreferrer"
+        target="_blank"
+      >
+        <Icon className="inline-block mr-2.5" />
+
+        <span className="text-md font-light mr-2.5">
+          {message}
+        </span>
+      </a>
+    </div>
+  );
+};

--- a/src/hooks/useVotedRepos.ts
+++ b/src/hooks/useVotedRepos.ts
@@ -6,7 +6,7 @@ import handleVoteUpdateByRepo from "../lib/handleVoteUpdateByRepo";
 
 const useVotedRepos = () => {
   const [votedReposIds, setVotedReposIds] = useState<number[]>([]);
-  const { signIn, user } = useSupabaseAuth();
+  const { signIn, userAndTokens } = useSupabaseAuth();
 
   const fetchVotedData = useCallback(async (user?: User) => {
     try {
@@ -26,7 +26,7 @@ const useVotedRepos = () => {
     votedReposIds.includes(parseInt(`${repo_id}`));
 
   const handleVoteUpdate = async (votes: number, repo_id: number) => {
-    const voteCount = await handleVoteUpdateByRepo(votes, repo_id, user?.user_metadata.sub);
+    const voteCount = await handleVoteUpdateByRepo(votes, repo_id, userAndTokens?.user.user_metadata.sub);
 
     handleVoted(repo_id);
 
@@ -44,14 +44,14 @@ const useVotedRepos = () => {
   };
 
   useEffect(() => {
-    fetchVotedData(user)
+    fetchVotedData(userAndTokens?.user)
       .catch(console.error);
-  }, [user]);
+  }, [userAndTokens?.user]);
 
   return {
     votedReposIds,
     checkVoted,
-    voteHandler: async (votes = 0, repo_id: number) => (user ? handleVoteUpdate(votes, repo_id) : signIn({ provider: "github" })),
+    voteHandler: async (votes = 0, repo_id: number) => (userAndTokens ? handleVoteUpdate(votes, repo_id) : signIn({ provider: "github" })),
   };
 };
 

--- a/src/lib/githubAPI.ts
+++ b/src/lib/githubAPI.ts
@@ -1,7 +1,11 @@
-async function getOpensaucedGoalsReposCount (): Promise<number> {
+export interface ReposCountFetchObject {
+  total_count: number;
+}
+
+export async function getOpensaucedGoalsReposCount (): Promise<number> {
   const res = await fetch(`https://api.github.com/search/repositories?q=open-sauced-goals&order=asc&per_page=100`);
 
-  const data = await res.json() as ReposCountFetchObject;
+  const data = (await res.json()) as ReposCountFetchObject;
 
   if (res.ok) {
     return data.total_count;
@@ -10,11 +14,13 @@ async function getOpensaucedGoalsReposCount (): Promise<number> {
   return 0;
 }
 
+export async function getUserStarredHotRepo (githubToken: string): Promise<boolean> {
+  const result = await fetch("https://api.github.com/user/starred/open-sauced/hot", {
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${githubToken}`,
+    },
+  });
 
-const githubAPI = { getOpensaucedGoalsReposCount };
-
-interface ReposCountFetchObject {
-  total_count: number;
+  return result.status === 204;
 }
-
-export default githubAPI;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

Uses the user's supabase provider (GitHub) token to check whether they've starred the repo using the [GitHub "Starring" REST API](https://docs.github.com/en/rest/activity/starring?apiVersion=2022-11-28#check-if-a-repository-is-starred-by-the-authenticated-user).
If they have, the header shows a filled star with _Starred on GitHub_ instead of an outline star with _Star us on GitHub_.

Because this switch takes place asynchronously, hides the messaging for pending logged-in users with a 200ms opacity transition to fade in.

## Related Tickets & Documents

Starts on #358.

Note: this doesn't add logic to `PUT` the user's star preference there. I'm getting 404s when I try and wanted to get this PR in for now. Is this ok for now?

## Mobile & Desktop Screenshots/Recordings

https://user-images.githubusercontent.com/3335181/209575166-9c92c5b6-aabc-4d14-9ccb-a6d953f36e3f.mov

## Added tests?

There aren't any `.test.tsx` files yet in the repository.
Would you like me to set up using `@testing-library/react` as part of these changes?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?


![Donald Duck twirling all smoothly in a tux](https://user-images.githubusercontent.com/3335181/209576013-fa3806ad-c492-4c1c-a1c6-e37a3f356609.gif)
