### PR TITLE
fix: remove height from footer to prevent socials from being truncate…

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -59,7 +59,7 @@ const footerContext = [
 
 const Footer = (): JSX.Element => (
   <div>
-    <footer className="px-6 md:px-16 h-24 w-full bg-light-slate-2 transition">
+    <footer className="px-6 md:px-16 w-full bg-light-slate-2 transition">
       <div className=" font-medium lg:border-t lg:py-8 lg:items-center lg:justify-between lg:gap-x-4 flex flex-col gap-y-4 lg:flex-row py-2 w-full">
         <div className="text-center lg:text-left justify-center gap-1 flex items-center">
           <div className="w-6 h-6 relative !min-w-[24px] min-h-[24px]">


### PR DESCRIPTION
…d in mobile view

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/open-sauced/blob/HEAD/CONTRIBUTING.md#create-a-pull-request.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/open-sauced/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

This PR fixes the footer bug in mobile view where the social icons are cut off due to the fixed height of the footer being smaller than its content. Fixed height removed.


## Related Tickets & Documents
Fixes #435 
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->
Before:
![Screen Shot 2023-01-04 at 9 50 25 PM (3)](https://user-images.githubusercontent.com/43274289/210690774-3d3469b2-dfc0-4026-9614-b3a7660f39a1.png)
After:
![Screen Shot 2023-01-04 at 9 50 50 PM (3)](https://user-images.githubusercontent.com/43274289/210690834-5c23f145-d250-4ec3-b232-90c358af2d02.png)


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?


![nervous](https://user-images.githubusercontent.com/43274289/210691843-2109b1ac-7f9a-44bf-8b94-f28a711657cf.gif)

<!-- note: PRs with deleted sections will be marked invalid -->

