### PR TITLE
fix: Pressing enter when searching no longer goes to about:blank

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -97,7 +97,8 @@ const Hero = () => {
                     setFocus(false);
                   }, 200)}
                 onKeyUp={(event: React.KeyboardEvent) => {
-                  if (event.key === "Enter") {
+                  // if no result is selected yet, then the comboBoxSelection will be empty, which will trigger a `about:blank` page to open
+                  if (event.key === "Enter" && comboBoxSelection !== "") {
                     window.open(comboBoxSelection, "_blank", "noreferrer");
                   }
                 }}


### PR DESCRIPTION
## Description

this pr fixes #501

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
fixes #501

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Steps to QA

try to press enter in the search repositories field, before the repos load

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
